### PR TITLE
The Phazon is now salvageable!

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -249,6 +249,22 @@
 	name = "\improper Phazon wreckage"
 	icon_state = "phazon-broken"
 
+/obj/structure/mecha_wreckage/phazon/Initialize()
+	. = ..()
+	var/list/parts = list(
+								/obj/item/mecha_parts/part/phazon_torso,
+								/obj/item/mecha_parts/part/phazon_head,
+								/obj/item/mecha_parts/part/phazon_left_arm,
+								/obj/item/mecha_parts/part/phazon_right_arm,
+								/obj/item/mecha_parts/part/phazon_left_leg,
+								/obj/item/mecha_parts/part/phazon_right_leg,
+								/obj/item/assembly/signaler/anomaly)
+	for(var/i = 0; i < 2; i++)
+		if(parts.len && prob(40))
+			var/part = pick(parts)
+			welder_salvage += part
+			parts -= part	
+
 
 /obj/structure/mecha_wreckage/odysseus
 	name = "\improper Odysseus wreckage"


### PR DESCRIPTION
The Phazon is now salvageable and there is a small chance of dropping an anomaly core.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I made the Phazon salvageable and there is a small chance of dropping an anomaly core!

## Why It's Good For The Game

You can finally try to get some Phazon parts from a Phazon wreckage, and it may have a gift! Yes, there is a small chance of getting an anomaly core from the wreckage!

## Changelog
:cl:
add: Phazon is now salvageable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
